### PR TITLE
use most up to date buildpack.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/heroku/heroku-buildpack-php


### PR DESCRIPTION
I think the default php buildpack we have on gigalixir is out of date. I'll update it soon.
In the meantime, you can use this pull request to use the most up to date buildpack.
I tested this and it seems to deploy fine, but I didn't test that the app works. Let me know if it doesn't and I can help you with that too.